### PR TITLE
[xmetrics-integration] Prevent external contributors from triggering workflows via PR comments

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ jobs:
           echo "github.event.comment.body: ${{ github.event.comment.body }}"
 
   get-example-list:
-    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' ) &&
+    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' ) &&
             github.event.issue.pull_request &&
             contains(github.event.comment.body, env.trigger-keyword ) }}
     runs-on: [e2-standard-8, linux]
@@ -78,7 +78,7 @@ jobs:
             -f context="Uptest-${{ steps.get-example-list-name.outputs.example-hash }}"
 
   uptest:
-    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' ) &&
+    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' ) &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, env.trigger-keyword ) }}
     runs-on: [e2-standard-8, linux]


### PR DESCRIPTION
### Description of your changes

This PR prevents external contributors from triggering workflows via PR comments.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
